### PR TITLE
Test app

### DIFF
--- a/a.txt
+++ b/a.txt
@@ -1,0 +1,223 @@
+The command:
+
+./gradlew app:api-application:run
+
+does the following:
+
+    Uses the Gradle Wrapper (./gradlew)
+
+        Ensures that the correct version of Gradle is used without requiring a global Gradle installation.
+
+    Targets the app:api-application module
+
+        From the folder structure in your screenshot, app is the root module, and api-application is a submodule inside it.
+
+    Runs the run task
+
+        This is typically used in applications built with the Gradle Application Plugin (id 'application' in build.gradle).
+
+        It executes the main class specified in build.gradle.
+
+Expected Outcome
+
+If api-application is configured correctly with an application plugin, the command will:
+
+    Compile the source code (src/main/kotlin/c0x12c.app)
+
+    Resolve dependencies
+
+    Execute the main entry point of the application
+
+Potential Issues
+
+    If application plugin is missing, run may not be available.
+
+    If mainClassName is not defined in build.gradle, Gradle may fail to locate the entry point.
+
+Would you like me to check if your build.gradle is configured correctly?
+You said:
+how to fix that: " Could not resolve com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2."
+ChatGPT said:
+
+The error "Could not resolve com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2." means that Gradle cannot find this dependency. Here’s how to fix it:
+1. Check if the Dependency is Correct
+
+Make sure your build.gradle (or build.gradle.kts if using Kotlin DSL) includes:
+For Groovy DSL (build.gradle)
+
+dependencies {
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2'
+}
+
+For Kotlin DSL (build.gradle.kts)
+
+dependencies {
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2")
+}
+
+2. Ensure You Have the Correct Repositories
+
+Make sure your repositories block includes Maven Central, since Jackson libraries are hosted there:
+For Groovy DSL
+
+repositories {
+    mavenCentral()
+}
+
+For Kotlin DSL
+
+repositories {
+    mavenCentral()
+}
+
+3. Refresh Dependencies
+
+Run the following command to force Gradle to refresh dependencies:
+
+./gradlew build --refresh-dependencies
+
+4. Check Internet Connection & Proxy
+
+If you are behind a firewall or using a proxy:
+
+    Ensure Gradle can access https://repo1.maven.org/maven2/
+
+    Try running:
+
+    ./gradlew build --refresh-dependencies --info
+
+    This provides more details on why Gradle is failing to resolve the dependency.
+
+5. Manually Check Dependency Availability
+
+Verify if the dependency exists on Maven Central:
+
+    Open Maven Repository: Jackson Dataformat YAML
+
+    If version 2.17.2 is not available, try using an older stable version like 2.16.1:
+
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1'
+
+6. Delete Cached Gradle Files
+
+If the dependency is corrupted in Gradle's cache, delete it and re-download:
+
+rm -rf ~/.gradle/caches
+./gradlew build
+
+7. Check for Gradle Version Compatibility
+
+Run:
+
+./gradlew --version
+
+If Gradle is outdated, update it in gradle-wrapper.properties or manually update your Gradle installation.
+Try these steps and let me know if the issue persists! 🚀
+You said:
+Error starting Micronaut server: Bean definition [c0x12c.app.controller.$UserPreferencesController$Definition$Intercepted] could not be loaded: Error instantiating bean of type  [c0x12c.database.runtime.DatabaseContext]
+ChatGPT said:
+
+Your Micronaut server fails to start because the DatabaseContext bean cannot be instantiated. Let's go step by step to diagnose and fix this.
+1. Check the DatabaseContext Bean Definition
+
+    Ensure DatabaseContext is annotated correctly:
+
+@Singleton
+class DatabaseContext {
+    // Database logic here
+}
+
+If it depends on configuration properties, ensure you have:
+
+    @Singleton
+    @Requires(property = "database.url")
+    class DatabaseContext(@Property(name = "database.url") val dbUrl: String) {
+        init {
+            println("Database URL: $dbUrl")
+        }
+    }
+
+    Fix: If a required property (e.g., database.url) is missing, add it to application.yml or .env.
+
+2. Check for Missing Dependencies
+
+    If DatabaseContext relies on external libraries like JDBC or an ORM (Hibernate, JPA), ensure they are included in build.gradle.
+
+For Groovy DSL (build.gradle)
+
+dependencies {
+    implementation("io.micronaut.data:micronaut-data-hibernate-jpa")
+    runtimeOnly("org.postgresql:postgresql") // Change based on your database
+}
+
+For Kotlin DSL (build.gradle.kts)
+
+dependencies {
+    implementation("io.micronaut.data:micronaut-data-hibernate-jpa")
+    runtimeOnly("org.postgresql:postgresql") // Adjust for your database
+}
+
+Run:
+
+./gradlew build --refresh-dependencies
+
+to ensure dependencies are resolved.
+3. Validate Configuration (application.yml or application.properties)
+
+Check if DatabaseContext is expecting a property that isn't set.
+Example application.yml
+
+datasources:
+  default:
+    url: jdbc:postgresql://localhost:5432/mydb
+    driverClassName: org.postgresql.Driver
+    username: user
+    password: pass
+    dialect: POSTGRES
+
+Example application.properties
+
+datasources.default.url=jdbc:postgresql://localhost:5432/mydb
+datasources.default.driverClassName=org.postgresql.Driver
+datasources.default.username=user
+datasources.default.password=pass
+datasources.default.dialect=POSTGRES
+
+Fix: If DatabaseContext relies on datasources.default, ensure these values exist.
+4. Check for Constructor Issues
+
+    If DatabaseContext has dependencies, check if they are injectable:
+
+    @Singleton
+    class DatabaseContext(private val config: DataSource) {
+        init {
+            println("Database initialized: ${config.url}")
+        }
+    }
+
+    If config cannot be injected, make sure DataSource is defined as a bean.
+
+5. Run in Debug Mode
+
+Use:
+
+./gradlew run --debug
+
+This will show detailed stack traces and indicate what exactly is failing.
+6. Delete Gradle Cache & Restart
+
+Try:
+
+rm -rf ~/.gradle/caches
+./gradlew clean build
+./gradlew run
+
+If a corrupted dependency or cache is causing the issue, this will fix it.
+7. Check Logs for More Details
+
+If the error persists, run:
+
+./gradlew run --stacktrace
+
+and share the full error output.
+Try these steps and let me know if it works! 🚀

--- a/components/perspective-transform-configure1.tsx
+++ b/components/perspective-transform-configure1.tsx
@@ -8,6 +8,230 @@ import { Label } from "@/components/ui/label"
 import { Upload, Undo, Redo } from 'lucide-react'
 import { NumericInputModal } from './numeric-input-modal'
 
+The command:
+
+./gradlew app:api-application:run
+
+does the following:
+
+    Uses the Gradle Wrapper (./gradlew)
+
+        Ensures that the correct version of Gradle is used without requiring a global Gradle installation.
+
+    Targets the app:api-application module
+
+        From the folder structure in your screenshot, app is the root module, and api-application is a submodule inside it.
+
+    Runs the run task
+
+        This is typically used in applications built with the Gradle Application Plugin (id 'application' in build.gradle).
+
+        It executes the main class specified in build.gradle.
+
+Expected Outcome
+
+If api-application is configured correctly with an application plugin, the command will:
+
+    Compile the source code (src/main/kotlin/c0x12c.app)
+
+    Resolve dependencies
+
+    Execute the main entry point of the application
+
+Potential Issues
+
+    If application plugin is missing, run may not be available.
+
+    If mainClassName is not defined in build.gradle, Gradle may fail to locate the entry point.
+
+Would you like me to check if your build.gradle is configured correctly?
+You said:
+how to fix that: " Could not resolve com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2."
+ChatGPT said:
+
+The error "Could not resolve com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2." means that Gradle cannot find this dependency. Here’s how to fix it:
+1. Check if the Dependency is Correct
+
+Make sure your build.gradle (or build.gradle.kts if using Kotlin DSL) includes:
+For Groovy DSL (build.gradle)
+
+dependencies {
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2'
+}
+
+For Kotlin DSL (build.gradle.kts)
+
+dependencies {
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2")
+}
+
+2. Ensure You Have the Correct Repositories
+
+Make sure your repositories block includes Maven Central, since Jackson libraries are hosted there:
+For Groovy DSL
+
+repositories {
+    mavenCentral()
+}
+
+For Kotlin DSL
+
+repositories {
+    mavenCentral()
+}
+
+3. Refresh Dependencies
+
+Run the following command to force Gradle to refresh dependencies:
+
+./gradlew build --refresh-dependencies
+
+4. Check Internet Connection & Proxy
+
+If you are behind a firewall or using a proxy:
+
+    Ensure Gradle can access https://repo1.maven.org/maven2/
+
+    Try running:
+
+    ./gradlew build --refresh-dependencies --info
+
+    This provides more details on why Gradle is failing to resolve the dependency.
+
+5. Manually Check Dependency Availability
+
+Verify if the dependency exists on Maven Central:
+
+    Open Maven Repository: Jackson Dataformat YAML
+
+    If version 2.17.2 is not available, try using an older stable version like 2.16.1:
+
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1'
+
+6. Delete Cached Gradle Files
+
+If the dependency is corrupted in Gradle's cache, delete it and re-download:
+
+rm -rf ~/.gradle/caches
+./gradlew build
+
+7. Check for Gradle Version Compatibility
+
+Run:
+
+./gradlew --version
+
+If Gradle is outdated, update it in gradle-wrapper.properties or manually update your Gradle installation.
+Try these steps and let me know if the issue persists! 🚀
+You said:
+Error starting Micronaut server: Bean definition [c0x12c.app.controller.$UserPreferencesController$Definition$Intercepted] could not be loaded: Error instantiating bean of type  [c0x12c.database.runtime.DatabaseContext]
+ChatGPT said:
+
+Your Micronaut server fails to start because the DatabaseContext bean cannot be instantiated. Let's go step by step to diagnose and fix this.
+1. Check the DatabaseContext Bean Definition
+
+    Ensure DatabaseContext is annotated correctly:
+
+@Singleton
+class DatabaseContext {
+    // Database logic here
+}
+
+If it depends on configuration properties, ensure you have:
+
+    @Singleton
+    @Requires(property = "database.url")
+    class DatabaseContext(@Property(name = "database.url") val dbUrl: String) {
+        init {
+            println("Database URL: $dbUrl")
+        }
+    }
+
+    Fix: If a required property (e.g., database.url) is missing, add it to application.yml or .env.
+
+2. Check for Missing Dependencies
+
+    If DatabaseContext relies on external libraries like JDBC or an ORM (Hibernate, JPA), ensure they are included in build.gradle.
+
+For Groovy DSL (build.gradle)
+
+dependencies {
+    implementation("io.micronaut.data:micronaut-data-hibernate-jpa")
+    runtimeOnly("org.postgresql:postgresql") // Change based on your database
+}
+
+For Kotlin DSL (build.gradle.kts)
+
+dependencies {
+    implementation("io.micronaut.data:micronaut-data-hibernate-jpa")
+    runtimeOnly("org.postgresql:postgresql") // Adjust for your database
+}
+
+Run:
+
+./gradlew build --refresh-dependencies
+
+to ensure dependencies are resolved.
+3. Validate Configuration (application.yml or application.properties)
+
+Check if DatabaseContext is expecting a property that isn't set.
+Example application.yml
+
+datasources:
+  default:
+    url: jdbc:postgresql://localhost:5432/mydb
+    driverClassName: org.postgresql.Driver
+    username: user
+    password: pass
+    dialect: POSTGRES
+
+Example application.properties
+
+datasources.default.url=jdbc:postgresql://localhost:5432/mydb
+datasources.default.driverClassName=org.postgresql.Driver
+datasources.default.username=user
+datasources.default.password=pass
+datasources.default.dialect=POSTGRES
+
+Fix: If DatabaseContext relies on datasources.default, ensure these values exist.
+4. Check for Constructor Issues
+
+    If DatabaseContext has dependencies, check if they are injectable:
+
+    @Singleton
+    class DatabaseContext(private val config: DataSource) {
+        init {
+            println("Database initialized: ${config.url}")
+        }
+    }
+
+    If config cannot be injected, make sure DataSource is defined as a bean.
+
+5. Run in Debug Mode
+
+Use:
+
+./gradlew run --debug
+
+This will show detailed stack traces and indicate what exactly is failing.
+6. Delete Gradle Cache & Restart
+
+Try:
+
+rm -rf ~/.gradle/caches
+./gradlew clean build
+./gradlew run
+
+If a corrupted dependency or cache is causing the issue, this will fix it.
+7. Check Logs for More Details
+
+If the error persists, run:
+
+./gradlew run --stacktrace
+
+and share the full error output.
+Try these steps and let me know if it works! 🚀
+
 interface Point {
   x: number
   y: number


### PR DESCRIPTION
This PR provides detailed troubleshooting steps for two common errors encountered in Gradle and Micronaut projects.

<details><summary>Gradle Dependency Resolution Error</summary>

- **Error:** Could not resolve `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2`
- **Solutions:**
  - Verify dependency declaration in `build.gradle` or `build.gradle.kts`
  - Ensure `mavenCentral()` repository is included
  - Refresh dependencies
  - Check internet and proxy settings
  - Manually verify dependency availability on Maven Central
  - Delete cached Gradle files
  - Check Gradle version compatibility

</details>

<details><summary>Micronaut Bean Instantiation Error</summary>

- **Error:** Micronaut server fails to start due to `DatabaseContext` bean instantiation
- **Solutions:**
  - Check `DatabaseContext` bean definition for correct annotations and property requirements
  - Ensure necessary dependencies like JDBC or ORM are included in `build.gradle`
  - Validate configuration in `application.yml` or `application.properties`
  - Check for constructor injection issues
  - Run in debug mode
  - Delete the Gradle cache
  - Check logs for detailed error outputs

</details>